### PR TITLE
Fix: Correct typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 openai 
 torch
 transformers
-cromadb
+chromadb
 streamlit
 pypdf2
 langchain_community


### PR DESCRIPTION
This commit fixes a typo in the requirements.tx, listing chromadb.